### PR TITLE
Remove concept of childProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-loader": "^6.2.8",
+    "babel-plugin-lodash": "^3.2.10",
     "babel-preset-react-app": "^1.0.0",
     "babel-register": "^6.18.0",
     "babel-root-import": "^4.1.4",
@@ -42,6 +43,7 @@
     "eslint-config-wpcalypso": "^0.6.0",
     "eslint-plugin-wpcalypso": "^3.0.2",
     "json-loader": "^0.5.4",
+    "lodash": "^4.17.2",
     "mocha": "^3.2.0",
     "onchange": "^3.0.2",
     "react": "^15.4.1",
@@ -55,7 +57,8 @@
   },
   "babel": {
     "plugins": [
-      "babel-root-import"
+      "babel-root-import",
+      "lodash"
     ],
     "presets": [
       "react-app"

--- a/server/class-component-themes-builder.php
+++ b/server/class-component-themes-builder.php
@@ -133,22 +133,21 @@ class Component_Themes_Builder {
 		}
 	}
 
-	private function build_component_from_config( $component_config, $component_data = [] ) {
+	private function build_component_from_config( $component_config ) {
 		if ( isset( $component_config['partial'] ) ) {
-			return $this->build_component_from_config( $this->get_partial_by_type( $component_config['partial'] ), $component_data );
+			return $this->build_component_from_config( $this->get_partial_by_type( $component_config['partial'] ) );
 		}
 		if ( ! isset( $component_config['componentType'] ) ) {
 			$name = ct_get_value( $component_config, 'id', json_encode( $component_config ) );
 			return $this->create_element( 'Component_Themes_Not_Found_Component', [ 'componentType' => $name ] );
 		}
 		$found_component = $this->get_component_by_type( $component_config['componentType'] );
-		$child_components = isset( $component_config['children'] ) ? array_map( function( $child ) use ( &$component_data ) {
-			return $this->build_component_from_config( $child, $component_data );
+		$child_components = isset( $component_config['children'] ) ? array_map( function( $child ) {
+			return $this->build_component_from_config( $child );
 		}, $component_config['children'] ) : [];
 		$props = ct_get_value( $component_config, 'props', [] );
 		$component_config['id'] = ct_get_value( $component_config, 'id', $this->generate_id( $component_config ) );
-		$data = ct_get_value( $component_data, $component_config['id'], [] );
-		$component_props = array_merge( $props, $data, [ 'componentId' => $component_config['id'], 'child_props' => $component_data, 'className' => $this->build_classname_for_component( $component_config ) ] );
+		$component_props = array_merge( $props, [ 'componentId' => $component_config['id'], 'className' => $this->build_classname_for_component( $component_config ) ] );
 		return $this->create_element( $found_component, $component_props, $child_components );
 	}
 
@@ -243,12 +242,12 @@ class Component_Themes_Builder {
 		return $theme;
 	}
 
-	private function build_components_from_theme( $theme_config, $page_config, $component_data ) {
+	private function build_components_from_theme( $theme_config, $page_config ) {
 		$this->register_partials( ct_get_value( $theme_config, 'partials', [] ) );
-		return $this->build_component_from_config( $this->expand_config_templates( $page_config, $theme_config ), $component_data );
+		return $this->build_component_from_config( $this->expand_config_templates( $page_config, $theme_config ) );
 	}
 
-	public function render( $theme_config, $page_config, $component_data = [] ) {
-		return React::render( $this->build_components_from_theme( $theme_config, $page_config, $component_data ) );
+	public function render( $theme_config, $page_config ) {
+		return React::render( $this->build_components_from_theme( $theme_config, $page_config ) );
 	}
 }

--- a/server/class-component-themes-builder.php
+++ b/server/class-component-themes-builder.php
@@ -76,10 +76,6 @@ class Component_Themes_Builder {
 		return new Component_Themes_Builder();
 	}
 
-	public function render_element( $component ) {
-		return $component->render();
-	}
-
 	public function create_element( $component, $props = [], $children = [] ) {
 		$context = ct_get_value( $props, 'context', [] );
 		$props = array_merge( $props, [ 'context' => $context ] );
@@ -253,6 +249,6 @@ class Component_Themes_Builder {
 	}
 
 	public function render( $theme_config, $page_config, $component_data = [] ) {
-		return $this->render_element( $this->build_components_from_theme( $theme_config, $page_config, $component_data ) );
+		return React::render( $this->build_components_from_theme( $theme_config, $page_config, $component_data ) );
 	}
 }

--- a/server/class-component-themes-component.php
+++ b/server/class-component-themes-component.php
@@ -1,40 +1,19 @@
 <?php
 class Component_Themes_Component {
-	protected $builder;
+	public $props;
+	public $children;
 
 	public function __construct( $props = [], $children = [] ) {
 		$this->props = $props;
 		$this->children = $children;
-		$this->builder = Component_Themes_Builder::get_builder();
 	}
 
 	public function get_prop( $key, $default = null ) {
 		return ct_get_value( $this->props, $key, $default );
 	}
 
-	public function get_prop_from_parent( $key, $default = null ) {
-		$child_props = ct_get_value( $this->props, 'child_props', [] );
-		return ct_get_value( $child_props, $key, $default );
-	}
-
-	public function make_component_with( $config, $data ) {
-		return $this->builder->make_component_with( $config, $data );
-	}
-
-	protected function render_child( $child ) {
-		if ( is_string( $child ) ) {
-			return $child;
-		}
-		return $child->render();
-	}
-
 	public function render_children() {
-		if ( ! is_array( $this->children ) ) {
-			return $this->render_child( $this->children );
-		}
-		return implode( ' ', array_map( function( $child ) {
-			return $this->render_child( $child );
-		}, $this->children ) );
+		return React::renderChildren( $this->children );
 	}
 
 	public function render() {

--- a/server/class-component-themes-helpers.php
+++ b/server/class-component-themes-helpers.php
@@ -17,6 +17,16 @@ function ct_array_flatten( $ary ) {
 		} else {
 			$result[] = $val;
 		}
-		return $result;
 	}
+	return $result;
+}
+
+function ct_omit( $ary, $keys ) {
+	$result = [];
+	foreach ( $ary as $key => $val ) {
+		if ( ! in_array( $key, $keys ) ) {
+			$result[ $key ] = $val;
+		}
+	}
+	return $result;
 }

--- a/server/class-component-themes-helpers.php
+++ b/server/class-component-themes-helpers.php
@@ -8,3 +8,15 @@ function ct_get_value( $ary, $key, $default = null ) {
 function ct_or( $val, $default ) {
 	return ! empty( $val ) ? $val : $default;
 }
+
+function ct_array_flatten( $ary ) {
+	$result = [];
+	foreach ( $ary as $val ) {
+		if ( is_array( $val ) ) {
+			$result = array_merge( $result, $val );
+		} else {
+			$result[] = $val;
+		}
+		return $result;
+	}
+}

--- a/server/class-react.php
+++ b/server/class-react.php
@@ -1,12 +1,63 @@
 <?php
 class React {
+	// @codingStandardsIgnoreStart
 	public static function createElement( $component, $props = [], $children = [] ) {
+		// @codingStandardsIgnoreEnd
 		$builder = Component_Themes_Builder::get_builder();
-		$out = $builder->create_element( $component, $props, $children );
+		return $builder->create_element( $component, $props, $children );
+	}
+
+	public static function render( $component ) {
+		if ( is_callable( $component ) ) {
+			return React::render( React::createElement( $component ) );
+		}
+		if ( is_string( $component ) ) {
+			return React::render( new Component_Themes_Text_Component( $component ) );
+		}
+		$out = $component->render();
 		if ( is_string( $out ) ) {
 			return $out;
 		}
-		return $out->render();
+		return React::render( $out );
+	}
+
+	// @codingStandardsIgnoreStart
+	public static function renderChildren( $children ) {
+		// @codingStandardsIgnoreEnd
+		$rendered_children = React::mapChildren( $children, function( $child ) {
+			return React::render( $child );
+		} );
+		return implode( ' ', $rendered_children );
+	}
+
+	// @codingStandardsIgnoreStart
+	public static function mapChildren( $children, $mapper ) {
+		// @codingStandardsIgnoreEnd
+		if ( ! $children ) {
+			return [];
+		}
+		if ( ! is_array( $children ) ) {
+			return [ call_user_func( $mapper, $children ) ];
+		}
+		return array_map( $mapper, $children );
+	}
+
+	// @codingStandardsIgnoreStart
+	public static function cloneElement( $component, $additional_props = [] ) {
+		// @codingStandardsIgnoreEnd
+		$props = $component->props;
+		$children = $component->children;
+		$props = array_merge( $props, $additional_props );
+		$component_type = get_class( $component );
+		if ( 'Component_Themes_Html_Component' === $component_type ) {
+			$tag = $component->tag;
+			return React::createElement( $tag, $props, $children );
+		}
+		if ( 'Component_Themes_Stateless_Component' === $component_type ) {
+			$render_function = $component->render_function;
+			return React::createElement( $render_function, $props, $children );
+		}
+		return React::createElement( $component_type, $props, $children );
 	}
 }
 

--- a/server/class-react.php
+++ b/server/class-react.php
@@ -14,9 +14,6 @@ class React {
 		if ( is_string( $component ) ) {
 			return React::render( new Component_Themes_Text_Component( $component ) );
 		}
-		if ( is_array( $component ) ) {
-			throw new Exception( 'Cannot call render on an array: ' . print_r( $component, true ) );
-		}
 		$out = $component->render();
 		if ( is_string( $out ) ) {
 			return $out;

--- a/server/class-react.php
+++ b/server/class-react.php
@@ -14,6 +14,9 @@ class React {
 		if ( is_string( $component ) ) {
 			return React::render( new Component_Themes_Text_Component( $component ) );
 		}
+		if ( is_array( $component ) ) {
+			throw new Exception( 'Cannot call render on an array: ' . print_r( $component, true ) );
+		}
 		$out = $component->render();
 		if ( is_string( $out ) ) {
 			return $out;

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ const ComponentThemes = {
 	apiDataWrapper,
 	makeComponentWith,
 	getPropsFromParent,
+	omit,
 };
 
 if ( typeof window !== 'undefined' ) {

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,6 @@ import omit from 'lodash/omit';
 import { ComponentThemePage } from '~/src/';
 import { apiDataWrapper } from '~/src/lib/api';
 import { registerComponent, registerPartial } from '~/src/lib/components';
-import { makeComponentWith, getPropsFromParent } from '~/src/lib/component-builder';
 import defaultTheme from '~/src/themes/default.json';
 
 const ComponentThemes = {
@@ -28,8 +27,6 @@ const ComponentThemes = {
 	registerComponent,
 	registerPartial,
 	apiDataWrapper,
-	makeComponentWith,
-	getPropsFromParent,
 	omit,
 };
 

--- a/src/lib/component-builder.js
+++ b/src/lib/component-builder.js
@@ -14,36 +14,30 @@ function buildComponent( Component, props = {}, children = [] ) {
 	return <Component key={ props.key } { ...props }>{ children }</Component>;
 }
 
-function buildComponentTreeFromConfig( componentConfig, childProps = {} ) {
+function buildComponentTreeFromConfig( componentConfig ) {
 	const { id, componentType, children, props, partial } = componentConfig;
 	if ( partial ) {
-		return buildComponentTreeFromConfig( getPartialByType( partial ), childProps );
+		return buildComponentTreeFromConfig( getPartialByType( partial ) );
 	}
 	const componentId = id || shortid.generate();
 	const Component = getComponentByType( componentType );
-	const childComponents = children ? children.map( child => buildComponentTreeFromConfig( child, childProps ) ) : null;
+	const childComponents = children ? children.map( child => buildComponentTreeFromConfig( child ) ) : null;
 	const componentProps = Object.assign(
 		{},
 		props || {},
-		{ childProps },
 		{ className: classNames( componentType, componentId ), key: componentId }
 	);
 	return { Component, componentId, componentProps, childComponents, componentType };
 }
 
-function getContentById( content, componentId, componentType ) {
-	return Object.assign( {}, content[ componentId ] || {}, content[ componentType ] || {} );
+function buildComponentFromTree( tree ) {
+	const { Component, componentProps, childComponents } = tree;
+	const children = childComponents ? childComponents.map( child => buildComponentFromTree( child ) ) : null;
+	return buildComponent( Component, componentProps, children );
 }
 
-function buildComponentFromTree( tree, content = {} ) {
-	const { Component, componentProps, childComponents, componentId, componentType } = tree;
-	const children = childComponents ? childComponents.map( child => buildComponentFromTree( child, content ) ) : null;
-	const props = Object.assign( {}, componentProps, getContentById( content, componentId, componentType ) );
-	return buildComponent( Component, props, children );
-}
-
-function buildComponentFromConfig( componentConfig, content = {} ) {
-	return buildComponentFromTree( buildComponentTreeFromConfig( componentConfig ), content );
+function buildComponentFromConfig( componentConfig ) {
+	return buildComponentFromTree( buildComponentTreeFromConfig( componentConfig ) );
 }
 
 function mergeThemeProperty( property, theme1, theme2 ) {
@@ -75,9 +69,9 @@ function registerPartials( partials ) {
 	Object.keys( partials ).map( key => registerPartial( key, partials[ key ] ) );
 }
 
-export function buildComponentsFromTheme( themeConfig, pageConfig, content = {} ) {
+export function buildComponentsFromTheme( themeConfig, pageConfig ) {
 	registerPartials( themeConfig.partials || {} );
-	return buildComponentFromConfig( expandConfigTemplates( pageConfig, themeConfig ), content );
+	return buildComponentFromConfig( expandConfigTemplates( pageConfig, themeConfig ) );
 }
 
 export function getTemplateForSlug( themeConfig, slug ) {

--- a/src/lib/component-builder.js
+++ b/src/lib/component-builder.js
@@ -31,16 +31,6 @@ function buildComponentTreeFromConfig( componentConfig, childProps = {} ) {
 	return { Component, componentId, componentProps, childComponents, componentType };
 }
 
-export function getPropsFromParent( mapPropsToProps ) {
-	return function( Child ) {
-		const ParentProps = ( props ) => {
-			const newProps = mapPropsToProps( props.childProps );
-			return <Child { ...newProps } { ...props } />;
-		};
-		return Object.assign( ParentProps, Child );
-	};
-}
-
 function getContentById( content, componentId, componentType ) {
 	return Object.assign( {}, content[ componentId ] || {}, content[ componentType ] || {} );
 }
@@ -50,10 +40,6 @@ function buildComponentFromTree( tree, content = {} ) {
 	const children = childComponents ? childComponents.map( child => buildComponentFromTree( child, content ) ) : null;
 	const props = Object.assign( {}, componentProps, getContentById( content, componentId, componentType ) );
 	return buildComponent( Component, props, children );
-}
-
-export function makeComponentWith( componentConfig, childProps = {} ) {
-	return buildComponentFromTree( buildComponentTreeFromConfig( componentConfig, childProps ) );
 }
 
 function buildComponentFromConfig( componentConfig, content = {} ) {

--- a/src/themes/README.md
+++ b/src/themes/README.md
@@ -51,7 +51,13 @@ Here is a slightly more realistic example of a theme for a blog (still without a
 					{ "id": "headerText", "componentType": "HeaderText" }
 				] },
 					{ "id": "contentLayout", "componentType": "RowComponent", "children": [
-						{ "id": "myPosts", "componentType": "PostList" },
+						{ "id": "myPosts", "componentType": "PostList", "children": [
+							{ "componentType": "PostBody", "children": [
+								{ "componentType": "PostTitle" },
+								{ "partial": "PostDateAndAuthor" },
+								{ "componentType": "PostContent" }
+							] }
+						] },
 						{ "id": "sidebarLayout", "componentType": "ColumnComponent", "children": [
 							{ "id": "sidebarSearch", "componentType": "SearchWidget" }
 						] }
@@ -70,11 +76,11 @@ You can read more about the format of Components in the [Components README](./co
 
 There are two main categories of components: **container** components and **content** components. Container components generally have few or no visual elements but serve to lay out other components. Content components display some content. Both are designed to be customized by providing props (content and settings).
 
-Each component in a page is an object that has at least two properties: `id` and `componentType`.
+Each component in a page is an object that has at least one of the properties: `componentType`, `partial`, or (in some cases) `template`.
 
 `componentType` is a string that refers to an existing component.
 
-`id` is a unique identifier string for that instance of the component.
+Any component using `componentType` can also specify `id` as a unique identifier string for that instance of the component.
 
 When styles are applied, they are selected by either the `componentType` (to affect all components of that type) or by `id` (to affect just one instance of a component in a page).
 
@@ -130,7 +136,13 @@ For example, here is a `header` partial used in a page:
 			{ "id": "pageLayout", "componentType": "ColumnComponent", "children": [
 				{ "partial": "header" },
 				{ "id": "contentLayout", "componentType": "RowComponent", "children": [
-					{ "id": "myPosts", "componentType": "PostList" }
+					{ "id": "myPosts", "componentType": "PostList", "children": [
+						{ "componentType": "PostBody", "children": [
+							{ "componentType": "PostTitle" },
+							{ "partial": "PostDateAndAuthor" },
+							{ "componentType": "PostContent" }
+						] }
+					] },
 				] }
 			] }
 		] }
@@ -161,61 +173,19 @@ For example, here is a `blog` template used as a home page:
 			{ "id": "pageLayout", "componentType": "ColumnComponent", "children": [
 				{ "partial": "header" },
 				{ "id": "contentLayout", "componentType": "RowComponent", "children": [
-					{ "id": "myPosts", "componentType": "PostList" }
+					{ "id": "myPosts", "componentType": "PostList", "children": [
+						{ "componentType": "PostBody", "children": [
+							{ "componentType": "PostTitle" },
+							{ "partial": "PostDateAndAuthor" },
+							{ "componentType": "PostContent" }
+						] }
+					] },
 				] }
 			] }
 		] },
 		"home": { "template": "blog" }
 	}
 }
-```
-
-## Components as props
-
-When rendering a component like `PostList` we need to iterate over a data set and render a React component for each data element.
-
-To define what React component is rendered, we need to pass that component as a prop to `PostList`. But we're not passing the created component, we're just passing the component *type*.
-
-Then, when rendered, PostList must iterate over its data, *create an instance of the passed component type*, and render that component, passing it the data element as props.
-
-This is normal React practice, but the difference here is that the component we're passing around is not a React component, it's part of a config. So in addition to the above, we need to transform the config object into a component before creating its instance.
-
-Specifying these components in the theme is just like regular components except they lack an `id` property:
-
-```json
-{ "id": "myPosts", "componentType": "PostList", "props": {
-	"post": { "componentType": "PostBody", "children": [
-		{ "componentType": "PostTitle" },
-		{ "componentType": "PostContent" },
-		{ "componentType": "PostDate" },
-		{ "componentType": "PostAuthor" },
-	] }
-} }
-```
-
-In order to build these component type objects into component instances, the `PostList` component must use `makeComponentWith()`. The function's first argument is a the component type object, and the second argument is the props that that component and all its children should have access to (see below):
-
-```js
-const postData = { "title": "My post" };
-const postType = { "componentType": "PostTitle" };
-const postList = posts.map( postData => makeComponentWith( postType, postData ) );
-```
-
-Components created in this way may have their own children (that are also JSON objects).
-
-What we do in this case is that the components passed to `PostList` are aware that they will need certain parameters and they can request them at their leisure when instantiated. This is similar to how Redux silently passes its state tree to all components and they choose what data they want.
-
-Any component created using `makeComponentWith( type, data )` or any descendant of that component will receive that `data` as a special prop which it can access using the Higher-Order-Component function (HOC) `getPropsFromParent()`:
-
-```js
-const PostTitle = ( { link, title } ) => {
-	//...
-};
-
-function mapProps( props ) {
-	return { link: props.link, title: props.title };
-}
-export default getPropsFromParent( mapProps )( PostTitle );
 ```
 
 ## Styles

--- a/src/themes/components/ColumnComponent/index.js
+++ b/src/themes/components/ColumnComponent/index.js
@@ -1,11 +1,14 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent } = ComponentThemes;
+const { React, registerComponent, omit } = ComponentThemes;
 
-const ColumnComponent = ( { children, className } ) => {
+const ColumnComponent = ( props ) => {
+	const { children, className } = props;
+	const childProps = omit( props, [ 'children', 'className' ] );
+	const newChildren = React.Children.map( children, child => React.cloneElement( child, { ...childProps } ) );
 	return (
 		<div className={ className }>
-			{ children }
+			{ newChildren }
 		</div>
 	);
 };

--- a/src/themes/components/ColumnComponent/index.php
+++ b/src/themes/components/ColumnComponent/index.php
@@ -1,9 +1,7 @@
 <?php
 $column_component = function( $props, $children ) {
 	$class_name = ct_get_value( $props, 'className', '' );
-	$new_props = $props;
-	unset( $new_props['className'] );
-	unset( $new_props['children'] );
+	$new_props = ct_omit( $props, [ 'className', 'children' ] );
 	$new_children = React::mapChildren( $children, function( $child ) use ( &$new_props ) {
 		return React::cloneElement( $child, $new_props );
 	} );

--- a/src/themes/components/ColumnComponent/index.php
+++ b/src/themes/components/ColumnComponent/index.php
@@ -1,9 +1,13 @@
 <?php
-class Component_Themes_ColumnComponent extends Component_Themes_Component {
-	public function render() {
-		return "<div class='" . $this->get_prop( 'className' ) . "'>" . $this->render_children() . '</div>';
-	}
-}
+$column_component = function( $props, $children ) {
+	$class_name = ct_get_value( $props, 'className', '' );
+	$new_props = $props;
+	unset( $new_props['className'] );
+	unset( $new_props['children'] );
+	$new_children = React::mapChildren( $children, function( $child ) use ( &$new_props ) {
+		return React::cloneElement( $child, $new_props );
+	} );
+	return React::createElement( 'div', [ 'className' => $class_name ], $new_children );
+};
 
-Component_Themes::register_component( 'ColumnComponent', 'Component_Themes_ColumnComponent' );
-
+Component_Themes::register_component( 'ColumnComponent', $column_component );

--- a/src/themes/components/PostAuthor/index.js
+++ b/src/themes/components/PostAuthor/index.js
@@ -1,6 +1,6 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent, getPropsFromParent } = ComponentThemes;
+const { React, registerComponent } = ComponentThemes;
 
 const PostAuthor = ( { author, className } ) => {
 	return (
@@ -18,5 +18,4 @@ PostAuthor.editableProps = {
 	},
 };
 
-const mapProps = ( { author } ) => ( { author } );
-registerComponent( 'PostAuthor', getPropsFromParent( mapProps )( PostAuthor ) );
+registerComponent( 'PostAuthor', PostAuthor );

--- a/src/themes/components/PostAuthor/index.php
+++ b/src/themes/components/PostAuthor/index.php
@@ -1,6 +1,6 @@
 <?php
 function Component_Themes_PostAuthor( $props, $children, $component ) {
-	$author = $component->get_prop_from_parent( 'author', 'No author' );
+	$author = $component->get_prop( 'author', 'No author' );
 	return "<span class='PostAuthor'>by $author</span>";
 }
 

--- a/src/themes/components/PostBody/index.js
+++ b/src/themes/components/PostBody/index.js
@@ -2,10 +2,11 @@
 const ComponentThemes = window.ComponentThemes;
 const { React, registerComponent } = ComponentThemes;
 
-const PostBody = ( { children, className } ) => {
+const PostBody = ( { content, date, link, author, title, children, className } ) => {
+	const newChildren = React.Children.map( children, child => React.cloneElement( child, { title, content, link, date, author } ) );
 	return (
 		<div className={ className }>
-			{ children }
+			{ newChildren }
 		</div>
 	);
 };

--- a/src/themes/components/PostBody/index.php
+++ b/src/themes/components/PostBody/index.php
@@ -1,8 +1,14 @@
 <?php
-class Component_Themes_PostBody extends Component_Themes_Component {
-	public function render() {
-		return "<div class='" . $this->get_prop( 'className' ) . "'>" . $this->render_children() . '</div>';
-	}
-}
+$post_body = function( $props, $children ) {
+	$class_name = ct_get_value( $props, 'className', '' );
+	$new_props = $props;
+	unset( $new_props['className'] );
+	unset( $new_props['children'] );
+	$new_children = React::mapChildren( $children, function( $child ) use ( &$new_props ) {
+		return React::cloneElement( $child, $new_props );
+	} );
+	return React::createElement( 'div', [ 'className' => $class_name ], $new_children );
+};
 
-Component_Themes::register_component( 'PostBody', 'Component_Themes_PostBody' );
+
+Component_Themes::register_component( 'PostBody', $post_body );

--- a/src/themes/components/PostBody/index.php
+++ b/src/themes/components/PostBody/index.php
@@ -2,8 +2,7 @@
 $post_body = function( $props, $children ) {
 	$class_name = ct_get_value( $props, 'className', '' );
 	$new_props = $props;
-	unset( $new_props['className'] );
-	unset( $new_props['children'] );
+	$new_props = ct_omit( $props, [ 'className', 'children' ] );
 	$new_children = React::mapChildren( $children, function( $child ) use ( &$new_props ) {
 		return React::cloneElement( $child, $new_props );
 	} );

--- a/src/themes/components/PostContent/index.js
+++ b/src/themes/components/PostContent/index.js
@@ -1,6 +1,6 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent, getPropsFromParent } = ComponentThemes;
+const { React, registerComponent } = ComponentThemes;
 
 function convertNewlines( content ) {
 	return content.replace( /\n/g, '<br />' );
@@ -25,5 +25,4 @@ PostContent.editableProps = {
 	}
 };
 
-const mapProps = ( { content } ) => ( { content } );
-registerComponent( 'PostContent', getPropsFromParent( mapProps )( PostContent ) );
+registerComponent( 'PostContent', PostContent );

--- a/src/themes/components/PostContent/index.php
+++ b/src/themes/components/PostContent/index.php
@@ -4,7 +4,7 @@ class Component_Themes_PostContent extends Component_Themes_Component {
 		$convert_newlines = function( $content ) {
 			return preg_replace( '/\n/', '<br/>', $content );
 		};
-		$content = $this->get_prop_from_parent( 'content', 'No content' );
+		$content = $this->get_prop( 'content', 'No content' );
 		return "<div class='PostContent'>" . $convert_newlines( $content ) . '</div>';
 	}
 }

--- a/src/themes/components/PostDate/index.js
+++ b/src/themes/components/PostDate/index.js
@@ -1,6 +1,6 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent, getPropsFromParent } = ComponentThemes;
+const { React, registerComponent } = ComponentThemes;
 
 const PostDate = ( { date, className } ) => {
 	return (
@@ -18,6 +18,5 @@ PostDate.editableProps = {
 	},
 };
 
-const mapProps = ( { date } ) => ( { date } );
-registerComponent( 'PostDate', getPropsFromParent( mapProps )( PostDate ) );
+registerComponent( 'PostDate', PostDate );
 

--- a/src/themes/components/PostDate/index.php
+++ b/src/themes/components/PostDate/index.php
@@ -1,6 +1,6 @@
 <?php
 function Component_Themes_PostDate( $props, $children, $component ) {
-	$date = $component->get_prop_from_parent( 'date', 'No date' );
+	$date = $component->get_prop( 'date', 'No date' );
 	return "<span class='PostDate'>$date</span>";
 }
 

--- a/src/themes/components/PostList/index.js
+++ b/src/themes/components/PostList/index.js
@@ -1,16 +1,14 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent, apiDataWrapper, makeComponentWith } = ComponentThemes;
+const { React, registerComponent, apiDataWrapper } = ComponentThemes;
 
-const PostList = ( { posts, post, className } ) => {
-	const defaultPostConfig = { componentType: 'PostBody', children: [
-		{ componentType: 'PostTitle' },
-		{ partial: 'PostDateAndAuthor' },
-		{ componentType: 'PostContent' }
-	] };
+const PostList = ( { posts, children, className } ) => {
+	const newChildren = ( posts || [] ).map( ( { title, link, content, author, date } ) => {
+		return React.Children.map( children, child => React.cloneElement( child, { title, link, content, author, date } ) );
+	} );
 	return (
 		<div className={ className }>
-			{ ( posts || [] ).map( postData => makeComponentWith( post || defaultPostConfig, postData ) ) }
+			{ newChildren }
 			{ ! posts || posts.length < 1 ? <p>No posts</p> : null }
 		</div>
 	);

--- a/src/themes/components/PostTitle/index.js
+++ b/src/themes/components/PostTitle/index.js
@@ -1,6 +1,6 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent, getPropsFromParent } = ComponentThemes;
+const { React, registerComponent } = ComponentThemes;
 
 const PostTitle = ( { link, title, className } ) => {
 	return (
@@ -22,5 +22,4 @@ PostTitle.editableProps = {
 	},
 };
 
-const mapProps = ( { link, title } ) => ( { link, title } );
-registerComponent( 'PostTitle', getPropsFromParent( mapProps )( PostTitle ) );
+registerComponent( 'PostTitle', PostTitle );

--- a/src/themes/components/PostTitle/index.php
+++ b/src/themes/components/PostTitle/index.php
@@ -1,12 +1,11 @@
 <?php
-class Component_Themes_PostTitle extends Component_Themes_Component {
-	public function render() {
-		$link = $this->get_prop_from_parent( 'link' );
-		$link_text = $this->get_prop_from_parent( 'title', 'No title' );
-		return "<h1 class='" . $this->get_prop( 'className' ) . "'>
-			<a class='PostTitle_link' href='$link'>$link_text</a>
+$post_title = function( $props ) {
+	$link = ct_get_value( $props, 'link' );
+	$link_text = ct_get_value( $props, 'title', 'No title' );
+	$class_name = ct_get_value( $props, 'className', '' );
+	return "<h1 class='$class_name'>
+		<a class='PostTitle_link' href='$link'>$link_text</a>
 		</h1>";
-	}
-}
+};
 
-Component_Themes::register_component( 'PostTitle', 'Component_Themes_PostTitle' );
+Component_Themes::register_component( 'PostTitle', $post_title );

--- a/src/themes/components/RowComponent/index.js
+++ b/src/themes/components/RowComponent/index.js
@@ -2,10 +2,19 @@
 const ComponentThemes = window.ComponentThemes;
 const { React, registerComponent, styled } = ComponentThemes;
 
-const RowComponent = ( { children, className } ) => {
+const RowComponent = ( props ) => {
+	const { children, className } = props;
+	// TODO: omit would be so nice; can we get it without all of lodash?
+	const childProps = Object.keys( props ).reduce( ( keep, propKey ) => {
+		if ( propKey !== 'children' && propKey !== 'className' ) {
+			return Object.assign( {}, keep, { [ propKey ]: props[ propKey ] } );
+		}
+		return keep;
+	}, {} );
+	const newChildren = React.Children.map( children, child => React.cloneElement( child, { ...childProps } ) );
 	return (
 		<div className={ className }>
-			{ children }
+			{ newChildren }
 		</div>
 	);
 };

--- a/src/themes/components/RowComponent/index.js
+++ b/src/themes/components/RowComponent/index.js
@@ -1,16 +1,10 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent, styled } = ComponentThemes;
+const { React, registerComponent, styled, omit } = ComponentThemes;
 
 const RowComponent = ( props ) => {
 	const { children, className } = props;
-	// TODO: omit would be so nice; can we get it without all of lodash?
-	const childProps = Object.keys( props ).reduce( ( keep, propKey ) => {
-		if ( propKey !== 'children' && propKey !== 'className' ) {
-			return Object.assign( {}, keep, { [ propKey ]: props[ propKey ] } );
-		}
-		return keep;
-	}, {} );
+	const childProps = omit( props, [ 'children', 'className' ] );
 	const newChildren = React.Children.map( children, child => React.cloneElement( child, { ...childProps } ) );
 	return (
 		<div className={ className }>

--- a/src/themes/components/RowComponent/index.php
+++ b/src/themes/components/RowComponent/index.php
@@ -2,8 +2,7 @@
 $row_component = function( $props, $children ) {
 	$class_name = ct_get_value( $props, 'className', '' );
 	$new_props = $props;
-	unset( $new_props['className'] );
-	unset( $new_props['children'] );
+	$new_props = ct_omit( $props, [ 'className', 'children' ] );
 	$new_children = React::mapChildren( $children, function( $child ) use ( &$new_props ) {
 		return React::cloneElement( $child, $new_props );
 	} );

--- a/src/themes/components/RowComponent/index.php
+++ b/src/themes/components/RowComponent/index.php
@@ -1,7 +1,13 @@
 <?php
 $row_component = function( $props, $children ) {
 	$class_name = ct_get_value( $props, 'className', '' );
-	return React::createElement( 'div', [ 'className' => $class_name ], $children );
+	$new_props = $props;
+	unset( $new_props['className'] );
+	unset( $new_props['children'] );
+	$new_children = React::mapChildren( $children, function( $child ) use ( &$new_props ) {
+		return React::cloneElement( $child, $new_props );
+	} );
+	return React::createElement( 'div', [ 'className' => $class_name ], $new_children );
 };
 
 $styled = Component_Themes::style_component( $row_component, '

--- a/src/themes/components/SinglePost/index.js
+++ b/src/themes/components/SinglePost/index.js
@@ -1,16 +1,12 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent, apiDataWrapper, makeComponentWith } = ComponentThemes;
+const { React, registerComponent, apiDataWrapper } = ComponentThemes;
 
-const SinglePost = ( { postData, post, className } ) => {
-	const defaultPostConfig = { componentType: 'PostBody', children: [
-		{ componentType: 'PostTitle' },
-		{ partial: 'PostDateAndAuthor' },
-		{ componentType: 'PostContent' }
-	] };
+const SinglePost = ( { postData, children, className } ) => {
+	const newChildren = React.Children.map( children, child => React.cloneElement( child, postData ) );
 	return (
 		<div className={ className }>
-			{ makeComponentWith( post || defaultPostConfig, postData ) }
+			{ newChildren }
 		</div>
 	);
 };

--- a/src/themes/components/SinglePost/index.php
+++ b/src/themes/components/SinglePost/index.php
@@ -1,25 +1,14 @@
 <?php
-class Component_Themes_SinglePost extends Component_Themes_Component {
-	public function render() {
-		$post_data = $this->get_prop( 'postData', [] );
-		$default_post_config = [
-			'componentType' => 'PostBody',
-			'children' => [
-				[ 'componentType' => 'PostTitle' ],
-				[ 'partial' => 'PostDateAndAuthor' ],
-				[ 'componentType' => 'PostContent' ],
-			],
-		];
-		$post_config = null !== $this->get_prop( 'post' ) ? $this->get_prop( 'post' ) : $default_post_config;
-		$render_blog_post = function( $post ) use ( &$post_config ) {
-			$component = $this->make_component_with( $post_config, $post );
-			return $component->render();
-		};
-		return "<div class='" . $this->get_prop( 'className' ) . "'>" . call_user_func( $render_blog_post, $post_data ) . '</div>';
-	}
-}
+$single_post = function( $props, $children ) {
+	$post_data = ct_get_value( $props, 'postData', [] );
+	$class_name = ct_get_value( $props, 'className', '' );
+	$new_children = React::mapChildren( $children, function( $child ) use ( &$post_data ) {
+		return React::cloneElement( $child, $post_data );
+	} );
+	return React::createElement( 'div', [ 'className' => $class_name ], $new_children );
+};
 
-$wrapped = Component_Themes::api_data_wrapper( 'Component_Themes_SinglePost', function( $get_api_endpoint, $state ) {
+$wrapped = Component_Themes::api_data_wrapper( $single_post, function( $get_api_endpoint, $state ) {
 	$info = ct_get_value( $state, 'pageInfo', [] );
 	$post_id = ct_get_value( $info, 'postId' );
 	if ( ! $post_id ) {

--- a/src/themes/default.json
+++ b/src/themes/default.json
@@ -8,7 +8,13 @@
 		"home": { "id": "pageLayout", "componentType": "PageLayout", "children": [
 			{ "partial": "PageHeader" },
 			{ "id": "contentLayout", "componentType": "RowComponent", "children": [
-				{ "id": "myPosts", "componentType": "PostList" }
+				{ "id": "myPosts", "componentType": "PostList", "children": [
+					{ "componentType": "PostBody", "children": [
+						{ "componentType": "PostTitle" },
+						{ "partial": "PostDateAndAuthor" },
+						{ "componentType": "PostContent" }
+					] }
+				] }
 			] },
 			{ "partial": "PageFooter" }
 		] }

--- a/tests/component-themes-builder.php
+++ b/tests/component-themes-builder.php
@@ -1,7 +1,7 @@
 <?php
 use function Corretto\describe, Corretto\it, Corretto\expect, Corretto\beforeEach;
 
-require( './server/class-component-themes.php' );
+require_once( './server/class-component-themes.php' );
 
 // @codingStandardsIgnoreStart
 function component_Themes_Text_Widget( $props ) {

--- a/tests/react.php
+++ b/tests/react.php
@@ -175,5 +175,18 @@ describe( 'React', function() {
 			expect( $result->props['foo'] )->toEqual( 'bar' );
 		} );
 	} );
+
+	describe( '::mapChildren()', function() {
+		it( 'returns the result of the mapping function for each component passed', function() {
+			$child1 = React::createElement( 'em' );
+			$child2 = React::createElement( 'b' );
+			$child3 = React::createElement( 'a' );
+			$childen = [ $child1, $child2, $child3 ];
+			$result = React::mapChildren( $childen, function( $child ) {
+				return $child->tag;
+			} );
+			expect( $result )->toEqual( [ 'em', 'b', 'a' ] );
+		} );
+	} );
 } );
 

--- a/tests/react.php
+++ b/tests/react.php
@@ -11,89 +11,168 @@ class My_Component extends Component_Themes_Component {
 
 describe( 'React', function() {
 	describe( '::createElement()', function() {
-		it( 'returns html for a simple html component', function() {
+		it( 'returns a component for a simple html string', function() {
 			$result = React::createElement( 'em' );
-			expect( $result )->toEqual( '<em></em>' );
+			expect( get_class( $result ) )->toEqual( 'Component_Themes_Html_Component' );
 		} );
 
-		it( 'returns html with properties for a simple html component with properties', function() {
+		it( 'renders html for a simple html component', function() {
+			$result = React::createElement( 'em' );
+			expect( React::render( $result ) )->toEqual( '<em></em>' );
+		} );
+
+		it( 'renders html with properties for a simple html component with properties', function() {
 			$result = React::createElement( 'a', [ 'href' => 'localhost' ] );
-			expect( $result )->toEqual( '<a href="localhost"></a>' );
+			expect( React::render( $result ) )->toEqual( '<a href="localhost"></a>' );
 		} );
 
-		it( 'returns html with properties for a simple html component with multiple properties', function() {
+		it( 'renders html with properties for a simple html component with multiple properties', function() {
 			$result = React::createElement( 'a', [ 'href' => 'localhost', 'foo' => 'bar' ] );
-			expect( $result )->toEqual( '<a href="localhost" foo="bar"></a>' );
+			expect( React::render( $result ) )->toEqual( '<a href="localhost" foo="bar"></a>' );
 		} );
 
-		it( 'returns html with "class" for a simple html component with "className" property', function() {
+		it( 'renders html with "class" for a simple html component with "className" property', function() {
 			$result = React::createElement( 'a', [ 'className' => 'great-link' ] );
-			expect( $result )->toEqual( '<a class="great-link"></a>' );
+			expect( React::render( $result ) )->toEqual( '<a class="great-link"></a>' );
 		} );
 
-		it( 'returns html which ignores properties which do not have a string value', function() {
+		it( 'renders html which ignores properties which do not have a string value', function() {
 			$result = React::createElement( 'a', [ 'className' => 'great-link', 'foo' => [ 'hello', 'world' ] ] );
-			expect( $result )->toEqual( '<a class="great-link"></a>' );
+			expect( React::render( $result ) )->toEqual( '<a class="great-link"></a>' );
 		} );
 
-		it( 'returns html with a text child included', function() {
+		it( 'renders html with a text child included', function() {
 			$result = React::createElement( 'a', [ 'className' => 'great-link' ], 'hello' );
-			expect( $result )->toEqual( '<a class="great-link">hello</a>' );
+			expect( React::render( $result ) )->toEqual( '<a class="great-link">hello</a>' );
 		} );
 
-		it( 'returns html with an element child included', function() {
+		it( 'renders html with an element child included', function() {
 			$child = React::createElement( 'b', [ 'className' => 'bold' ], 'hello' );
 			$result = React::createElement( 'a', [ 'className' => 'great-link' ], $child );
-			expect( $result )->toEqual( '<a class="great-link"><b class="bold">hello</b></a>' );
+			expect( React::render( $result ) )->toEqual( '<a class="great-link"><b class="bold">hello</b></a>' );
 		} );
 
-		it( 'returns html with multiple element children included, separated by spaces', function() {
+		it( 'renders html with multiple element children included, separated by spaces', function() {
 			$child1 = React::createElement( 'b', [ 'className' => 'bold' ], 'hello' );
 			$child2 = React::createElement( 'em', [ 'className' => 'emphasis' ], 'world' );
 			$result = React::createElement( 'a', [ 'className' => 'great-link' ], [ $child1, 'there,', $child2 ] );
-			expect( $result )->toEqual( '<a class="great-link"><b class="bold">hello</b> there, <em class="emphasis">world</em></a>' );
+			expect( React::render( $result ) )->toEqual( '<a class="great-link"><b class="bold">hello</b> there, <em class="emphasis">world</em></a>' );
 		} );
 
-		it( 'returns html for a simple function component that returns a string', function() {
+		it( 'renders html for a simple function component that returns a string', function() {
 			$component = function() {
 				return '<b>hello</b>';
 			};
 			$result = React::createElement( $component );
-			expect( $result )->toEqual( '<b>hello</b>' );
+			expect( React::render( $result ) )->toEqual( '<b>hello</b>' );
 		} );
 
-		it( 'returns html for a simple function component that returns a component', function() {
+		it( 'renders html for a simple function component that returns a component', function() {
 			$component = function() {
 				return React::createElement( 'b', [], 'hello' );
 			};
 			$result = React::createElement( $component );
-			expect( $result )->toEqual( '<b>hello</b>' );
+			expect( React::render( $result ) )->toEqual( '<b>hello</b>' );
 		} );
 
-		it( 'returns html for a function component with props', function() {
+		it( 'renders html for a function component with props', function() {
 			$component = function( $props ) {
 				return React::createElement( 'b', [], ct_get_value( $props, 'name' ) );
 			};
 			$result = React::createElement( $component, [ 'name' => 'hello' ] );
-			expect( $result )->toEqual( '<b>hello</b>' );
+			expect( React::render( $result ) )->toEqual( '<b>hello</b>' );
 		} );
 
-		it( 'returns html for a function component with children', function() {
+		it( 'renders html for a function component with children', function() {
 			$component = function( $props, $children ) {
 				return React::createElement( 'b', [], $children );
 			};
 			$result = React::createElement( $component, [], 'hello' );
-			expect( $result )->toEqual( '<b>hello</b>' );
+			expect( React::render( $result ) )->toEqual( '<b>hello</b>' );
 		} );
 
-		it( 'returns html for a simple class component that returns a string', function() {
+		it( 'renders html for a simple class component that returns a string', function() {
 			$result = React::createElement( 'My_Component' );
-			expect( $result )->toEqual( '<b>hello</b>' );
+			expect( React::render( $result ) )->toEqual( '<b>hello</b>' );
 		} );
 
-		it( 'returns html for a class component with props', function() {
+		it( 'renders html for a class component with props', function() {
 			$result = React::createElement( 'My_Component', [ 'name' => ' world' ] );
-			expect( $result )->toEqual( '<b>hello world</b>' );
+			expect( React::render( $result ) )->toEqual( '<b>hello world</b>' );
+		} );
+	} );
+
+	describe( '::cloneElement()', function() {
+		it( 'returns an html component with the same tag as the passed component', function() {
+			$component = React::createElement( 'em' );
+			$result = React::cloneElement( $component );
+			expect( React::render( $result ) )->toEqual( '<em></em>' );
+		} );
+
+		it( 'returns an html component which is a different instance than the passed component', function() {
+			$component = React::createElement( 'em' );
+			$result = React::cloneElement( $component );
+			expect( $result )->toNotEqual( $component );
+		} );
+
+		it( 'returns an html component with the same props as the passed component', function() {
+			$component = React::createElement( 'em', [ 'foo' => 'bar' ] );
+			$result = React::cloneElement( $component );
+			expect( $result->props['foo'] )->toEqual( 'bar' );
+		} );
+
+		it( 'returns an html component with the same children as the passed component', function() {
+			$component = React::createElement( 'em', [], 'hello' );
+			$result = React::cloneElement( $component );
+			expect( React::render( $result ) )->toEqual( '<em>hello</em>' );
+		} );
+
+		it( 'returns an html component with its props overridden by the passed props', function() {
+			$component = React::createElement( 'em', [ 'foo' => 'bar' ], 'hello' );
+			$result = React::cloneElement( $component, [ 'foo' => 'baz' ] );
+			expect( React::render( $result ) )->toEqual( '<em foo="baz">hello</em>' );
+		} );
+
+		it( 'returns a function component which renders the same string as the passed component', function() {
+			$component = React::createElement( function() {
+				return '<b>hello</b>';
+			} );
+			$result = React::cloneElement( $component );
+			expect( React::render( $result ) )->toEqual( '<b>hello</b>' );
+		} );
+
+		it( 'returns a function component which is a different instance than the passed component', function() {
+			$component = React::createElement( function() {
+				return '<b>hello</b>';
+			} );
+			$result = React::cloneElement( $component );
+			expect( $result )->toNotEqual( $component );
+		} );
+
+		it( 'returns a function component with its props set by the passed props', function() {
+			$component = React::createElement( function() {
+				return '<b>hello</b>';
+			} );
+			$result = React::cloneElement( $component, [ 'foo' => 'bar' ] );
+			expect( $result->props['foo'] )->toEqual( 'bar' );
+		} );
+
+		it( 'returns a class component which renders the same string as the passed component', function() {
+			$component = React::createElement( 'My_Component' );
+			$result = React::cloneElement( $component );
+			expect( React::render( $result ) )->toEqual( '<b>hello</b>' );
+		} );
+
+		it( 'returns a class component which is a different instance than the passed component', function() {
+			$component = React::createElement( 'My_Component' );
+			$result = React::cloneElement( $component );
+			expect( $result )->toNotEqual( $component );
+		} );
+
+		it( 'returns a class component with its props set by the passed props', function() {
+			$component = React::createElement( 'My_Component' );
+			$result = React::cloneElement( $component, [ 'foo' => 'bar' ] );
+			expect( $result->props['foo'] )->toEqual( 'bar' );
 		} );
 	} );
 } );

--- a/tests/react.php
+++ b/tests/react.php
@@ -1,0 +1,100 @@
+<?php
+use function Corretto\describe, Corretto\it, Corretto\expect, Corretto\beforeEach;
+
+require_once( './server/class-component-themes.php' );
+
+class My_Component extends Component_Themes_Component {
+	public function render() {
+		return '<b>hello' . ct_get_value( $this->props, 'name', '' ) . '</b>';
+	}
+}
+
+describe( 'React', function() {
+	describe( '::createElement()', function() {
+		it( 'returns html for a simple html component', function() {
+			$result = React::createElement( 'em' );
+			expect( $result )->toEqual( '<em></em>' );
+		} );
+
+		it( 'returns html with properties for a simple html component with properties', function() {
+			$result = React::createElement( 'a', [ 'href' => 'localhost' ] );
+			expect( $result )->toEqual( '<a href="localhost"></a>' );
+		} );
+
+		it( 'returns html with properties for a simple html component with multiple properties', function() {
+			$result = React::createElement( 'a', [ 'href' => 'localhost', 'foo' => 'bar' ] );
+			expect( $result )->toEqual( '<a href="localhost" foo="bar"></a>' );
+		} );
+
+		it( 'returns html with "class" for a simple html component with "className" property', function() {
+			$result = React::createElement( 'a', [ 'className' => 'great-link' ] );
+			expect( $result )->toEqual( '<a class="great-link"></a>' );
+		} );
+
+		it( 'returns html which ignores properties which do not have a string value', function() {
+			$result = React::createElement( 'a', [ 'className' => 'great-link', 'foo' => [ 'hello', 'world' ] ] );
+			expect( $result )->toEqual( '<a class="great-link"></a>' );
+		} );
+
+		it( 'returns html with a text child included', function() {
+			$result = React::createElement( 'a', [ 'className' => 'great-link' ], 'hello' );
+			expect( $result )->toEqual( '<a class="great-link">hello</a>' );
+		} );
+
+		it( 'returns html with an element child included', function() {
+			$child = React::createElement( 'b', [ 'className' => 'bold' ], 'hello' );
+			$result = React::createElement( 'a', [ 'className' => 'great-link' ], $child );
+			expect( $result )->toEqual( '<a class="great-link"><b class="bold">hello</b></a>' );
+		} );
+
+		it( 'returns html with multiple element children included, separated by spaces', function() {
+			$child1 = React::createElement( 'b', [ 'className' => 'bold' ], 'hello' );
+			$child2 = React::createElement( 'em', [ 'className' => 'emphasis' ], 'world' );
+			$result = React::createElement( 'a', [ 'className' => 'great-link' ], [ $child1, 'there,', $child2 ] );
+			expect( $result )->toEqual( '<a class="great-link"><b class="bold">hello</b> there, <em class="emphasis">world</em></a>' );
+		} );
+
+		it( 'returns html for a simple function component that returns a string', function() {
+			$component = function() {
+				return '<b>hello</b>';
+			};
+			$result = React::createElement( $component );
+			expect( $result )->toEqual( '<b>hello</b>' );
+		} );
+
+		it( 'returns html for a simple function component that returns a component', function() {
+			$component = function() {
+				return React::createElement( 'b', [], 'hello' );
+			};
+			$result = React::createElement( $component );
+			expect( $result )->toEqual( '<b>hello</b>' );
+		} );
+
+		it( 'returns html for a function component with props', function() {
+			$component = function( $props ) {
+				return React::createElement( 'b', [], ct_get_value( $props, 'name' ) );
+			};
+			$result = React::createElement( $component, [ 'name' => 'hello' ] );
+			expect( $result )->toEqual( '<b>hello</b>' );
+		} );
+
+		it( 'returns html for a function component with children', function() {
+			$component = function( $props, $children ) {
+				return React::createElement( 'b', [], $children );
+			};
+			$result = React::createElement( $component, [], 'hello' );
+			expect( $result )->toEqual( '<b>hello</b>' );
+		} );
+
+		it( 'returns html for a simple class component that returns a string', function() {
+			$result = React::createElement( 'My_Component' );
+			expect( $result )->toEqual( '<b>hello</b>' );
+		} );
+
+		it( 'returns html for a class component with props', function() {
+			$result = React::createElement( 'My_Component', [ 'name' => ' world' ] );
+			expect( $result )->toEqual( '<b>hello world</b>' );
+		} );
+	} );
+} );
+

--- a/themes/kubrick/theme.json
+++ b/themes/kubrick/theme.json
@@ -29,7 +29,13 @@
 		"post": { "id": "pageLayout", "componentType": "PageLayout", "children": [
 			{ "partial": "PageHeader" },
 			{ "id": "singlePostContentLayout", "componentType": "RowComponent", "children": [
-				{ "id": "thePost", "componentType": "SinglePost" }
+				{ "id": "thePost", "componentType": "SinglePost", "children": [
+					{ "componentType": "PostBody", "children": [
+						{ "componentType": "PostTitle" },
+						{ "partial": "PostDateAndAuthor" },
+						{ "componentType": "PostContent" }
+					] }
+				] }
 			] },
 			{ "partial": "PageFooter" }
 		] }

--- a/themes/kubrick/theme.json
+++ b/themes/kubrick/theme.json
@@ -15,7 +15,13 @@
 		"home": { "id": "pageLayout", "componentType": "PageLayout", "children": [
 			{ "partial": "PageHeader" },
 			{ "id": "homeContentLayout", "componentType": "RowComponent", "children": [
-				{ "id": "myPosts", "componentType": "PostList" },
+				{ "id": "myPosts", "componentType": "PostList", "children": [
+					{ "componentType": "PostBody", "children": [
+						{ "componentType": "PostTitle" },
+						{ "partial": "PostDateAndAuthor" },
+						{ "componentType": "PostContent" }
+					] }
+				] },
 				{ "partial": "PageSidebar" }
 			] },
 			{ "partial": "PageFooter" }


### PR DESCRIPTION
Child props (`makeComponentWithProps`, `getPropsFromParent`, etc.) were always a bit of a hack.

This PR removes them in favor of using `React.cloneElement` to automatically pass props down to children when they will be needed. It also removes needing to pass components as props since the children of a component can in fact be cloned multiple times.