### PR TITLE
Client-side routing support

### DIFF
--- a/includes/class-component-themes-rest-api.php
+++ b/includes/class-component-themes-rest-api.php
@@ -1,0 +1,21 @@
+<?php
+
+class Component_Themes_Rest_API {
+
+	var $namespace = 'component-themes/v1';
+
+	function init() {
+		register_rest_route( $this->namespace, '/settings', array( 'methods' => 'GET', 'callback' => array( $this, 'settings' ) ) );
+	}
+
+	function settings( $data ) {
+		return array(
+			'name' => get_bloginfo( 'name' ),
+			'url' => get_bloginfo( 'url' ),
+			'wpurl' => get_bloginfo( 'wpurl' ),
+			'description' => get_bloginfo( 'description' ),
+			'date_format' => get_option( 'date_format' ),
+			'time_format' => get_option( 'time_format' ),
+		);
+	}
+}

--- a/includes/class-component-themes.php
+++ b/includes/class-component-themes.php
@@ -59,6 +59,7 @@ class Component_Themes_Plugin {
 		$this->load_dependencies();
 		$this->set_locale();
 		$this->define_public_hooks();
+		$this->add_rest_api();
 
 	}
 
@@ -90,7 +91,10 @@ class Component_Themes_Plugin {
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-component-themes-public.php';
 
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-component-themes-rest-api.php';
+
 		$this->loader = new Component_Themes_Loader();
+		$this->rest_api = new Component_Themes_Rest_API();
 
 	}
 
@@ -173,4 +177,7 @@ class Component_Themes_Plugin {
 		return $this->version;
 	}
 
+	public function add_rest_api() {
+		add_action( 'rest_api_init', array( $this->rest_api, 'init' ) );
+	}
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-dom": "^15.4.1",
     "shortid": "^2.2.6",
     "styled-components": "^1.1.2",
+    "tiny-emitter": "^1.1.0",
     "traverse": "^0.6.6",
     "webpack": "^1.13.3",
     "whatwg-fetch": "^2.0.1"

--- a/public/class-component-themes-public.php
+++ b/public/class-component-themes-public.php
@@ -62,7 +62,12 @@ class Component_Themes_Public {
 			<div id="root">
 <?php
 require_once( plugin_dir_path( dirname( __FILE__ ) ) . 'server/class-component-themes.php' );
+require_once( plugin_dir_path( dirname( __FILE__ ) ) . 'server/class-component-themes-api.php' );
 require_once( plugin_dir_path( dirname( __FILE__ ) ) . 'server/core-components.php' );
+
+// always fetch general settings
+Component_Themes_Api::get_api_endpoint( '/component-themes/v1/settings' );
+
 $theme_config = json_decode( file_get_contents( plugin_dir_path( dirname( __FILE__ ) ) . 'themes/kubrick/theme.json' ), true );
 $page_config = null;
 $page_slug = ( is_home() || is_front_page() ) ? 'home' : get_post_field( 'post_name', get_post() );

--- a/public/class-component-themes-public.php
+++ b/public/class-component-themes-public.php
@@ -84,10 +84,14 @@ if ( ! isset( $_GET['ssr'] ) ):
 		<script src="<?php echo $plugin_dir_url; ?>build/app.js"></script>
 		<script src="<?php echo $plugin_dir_url; ?>build/core-components.js"></script>
 		<script type="text/javascript">
-		const themeConfig = <?php echo json_encode( $theme_config ); ?>;
-		const pageConfig = <?php echo json_encode( $page_config ); ?>;
-		const pageInfo = <?php echo json_encode( $page_info ); ?>;
-		ComponentThemes.renderPage( themeConfig, pageInfo, pageConfig, window.document.getElementById( 'root' ) );
+		ComponentThemes.storage.update({
+			apiData: window.ComponentThemesApiData || {},
+			themeConfig: <?php echo json_encode( $theme_config ); ?>,
+			pageConfig: <?php echo json_encode( $page_config ); ?>,
+			pageInfo: <?php echo json_encode( $page_info ); ?>,
+		});
+		ComponentThemes.rootElement = document.getElementById( 'root' );
+		ComponentThemes.renderPage( ComponentThemes.rootElement );
 		</script>
 <?php
 endif;

--- a/server/class-component-themes-builder.php
+++ b/server/class-component-themes-builder.php
@@ -86,6 +86,13 @@ class Component_Themes_Builder {
 	public function create_element( $component, $props = array(), $children = array() ) {
 		$props = array_merge( array( 'context' => array() ), $props ? $props : array() );
 
+		if ( is_string( $component ) ) {
+			if ( ctype_lower( $component[0] ) ) {
+				return new Component_Themes_Html_Component( $component, $props, $children );
+			} elseif ( isset( self::$registered_components[ $component ] ) ) {
+				$component = self::$registered_components[ $component ];
+			}
+		}
 		if ( $component instanceof Component_Themes_Component ) {
 			return $component;
 		}
@@ -94,9 +101,6 @@ class Component_Themes_Builder {
 		}
 		if ( is_callable( $component ) ) {
 			return new Component_Themes_Stateless_Component( $component, $props, $children );
-		}
-		if ( is_string( $component ) && ! ctype_upper( $component[0] ) ) {
-			return new Component_Themes_Html_Component( $component, $props, $children );
 		}
 		if ( 'Component_Themes_Text_Component' === $component ) {
 			// This would be an error state, but to prevent errors, we will make an empty text node

--- a/server/core-components.php
+++ b/server/core-components.php
@@ -12,5 +12,6 @@ require( __DIR__ . '/../src/themes/components/PostContent/index.php' );
 require( __DIR__ . '/../src/themes/components/ColumnComponent/index.php' );
 require( __DIR__ . '/../src/themes/components/FooterText/index.php' );
 require( __DIR__ . '/../src/themes/components/HeaderText/index.php' );
+require( __DIR__ . '/../src/themes/components/Link/index.php' );
 require( __DIR__ . '/../src/themes/components/PageLayout/index.php' );
 require( __DIR__ . '/../src/themes/components/SinglePost/index.php' );

--- a/src/app.js
+++ b/src/app.js
@@ -13,24 +13,33 @@ import omit from 'lodash/omit';
  */
 import { ComponentThemePage } from '~/src/';
 import { apiDataWrapper } from '~/src/lib/api';
-import { registerComponent, registerPartial } from '~/src/lib/components';
+import { registerComponent, registerPartial, getComponentByType } from '~/src/lib/components';
 import date from '~/src/lib/date';
+import route from '~/src/lib/route';
+import storage from '~/src/lib/storage';
 import defaultTheme from '~/src/themes/default.json';
 
 const ComponentThemes = {
-	renderPage: function( theme, info, page, target ) {
-		const App = <ComponentThemePage theme={ theme } defaultTheme={ defaultTheme } page={ page } info={ info } />;
-		ReactDOM.render( App, target );
+	renderPage( target ) {
+		var { themeConfig, pageInfo, pageConfig } = storage.get();
+		const App = <ComponentThemePage theme={ themeConfig } defaultTheme={ defaultTheme } page={ pageConfig } info={ pageInfo } />;
+		if ( target || this.rootElement ) {
+			ReactDOM.render( App, target || this.rootElement );
+		}
 	},
-
 	React,
 	styled,
 	registerComponent,
 	registerPartial,
+	getComponentByType,
 	apiDataWrapper,
 	omit,
 	date,
+	storage,
+	route,
 };
+
+storage.on( 'update', () => ComponentThemes.renderPage() );
 
 if ( typeof window !== 'undefined' ) {
 	window.ComponentThemes = ComponentThemes;

--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,7 @@ import defaultTheme from '~/src/themes/default.json';
 
 const ComponentThemes = {
 	renderPage( target ) {
-		var { themeConfig, pageInfo, pageConfig } = storage.get();
+		const { themeConfig, pageInfo, pageConfig } = storage.get();
 		const App = <ComponentThemePage theme={ themeConfig } defaultTheme={ defaultTheme } page={ pageConfig } info={ pageInfo } />;
 		if ( target || this.rootElement ) {
 			ReactDOM.render( App, target || this.rootElement );

--- a/src/components/ComponentThemePage.js
+++ b/src/components/ComponentThemePage.js
@@ -12,9 +12,6 @@ import { buildComponentsFromTheme, getTemplateForSlug, mergeThemes } from '~/src
 import { apiDataProvider } from '~/src/lib/api';
 
 class ComponentThemePage extends Component {
-	componentWillMount() {
-		this.props.setPageInfo( this.props.info );
-	}
 
 	render() {
 		const theme = mergeThemes( this.props.defaultTheme || {}, this.props.theme );

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -31,11 +31,6 @@ function fetchRequiredApiEndpoint( endpoint ) {
 	} );
 }
 
-export function getBootstrappedRequiredApiData() {
-	const data = storage.get();
-	return { api: data.apiData.api || {}, pageInfo: data.pageInfo || {} };
-}
-
 export function apiDataWrapper( mapApiToProps ) {
 	return ( Target ) => {
 		const ApiDataWrapper = ( props, context ) => {
@@ -78,7 +73,6 @@ export function apiDataProvider() {
 			setPageInfo( info ) {
 				const data = storage.get();
 				data.pageInfo = Object.assign( {}, data.pageInfo, info );
-				console.log(info);
 				storage.update( data );
 			}
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -7,6 +7,8 @@ import React from 'react';
 import 'es6-promise/auto';
 import 'whatwg-fetch';
 
+import storage from './storage';
+
 function checkStatus( response ) {
 	if ( response.status >= 200 && response.status < 300 ) {
 		return response;
@@ -22,7 +24,7 @@ function parseJson( response ) {
 
 function fetchRequiredApiEndpoint( endpoint ) {
 	return new Promise( resolve => {
-		fetch( '/wp-json' + endpoint )
+		fetch( '/?rest_route=' + endpoint )
 		.then( checkStatus )
 		.then( parseJson )
 		.then( json => resolve( { [ endpoint ]: json } ) );
@@ -30,10 +32,8 @@ function fetchRequiredApiEndpoint( endpoint ) {
 }
 
 export function getBootstrappedRequiredApiData() {
-	if ( window.ComponentThemesApiData ) {
-		return window.ComponentThemesApiData;
-	}
-	return { api: {}, pageInfo: {} };
+	const data = storage.get();
+	return { api: data.apiData.api || {}, pageInfo: data.pageInfo || {} };
 }
 
 export function apiDataWrapper( mapApiToProps ) {
@@ -64,26 +64,31 @@ export function apiDataProvider() {
 				this.setPageInfo = this.setPageInfo.bind( this );
 				this.getApiEndpoint = this.getApiEndpoint.bind( this );
 				this.fetchApiData = this.fetchApiData.bind( this );
-				const apiProps = getBootstrappedRequiredApiData();
-				this.state = { apiProps };
+			}
+
+			getApiProps() {
+				const data = storage.get();
+				return { api: data.apiData.api || {}, pageInfo: data.pageInfo || {} };
 			}
 
 			getChildContext() {
-				return { apiProps: this.state.apiProps, fetchApiData: this.fetchApiData, getApiEndpoint: this.getApiEndpoint };
+				return { apiProps: this.getApiProps(), fetchApiData: this.fetchApiData, getApiEndpoint: this.getApiEndpoint };
 			}
 
 			setPageInfo( info ) {
-				const pageInfo = Object.assign( {}, this.state.apiProps.pageInfo, info );
-				const apiProps = Object.assign( {}, this.state.apiProps, { pageInfo } );
-				this.setState( { apiProps } );
+				const data = storage.get();
+				data.pageInfo = Object.assign( {}, data.pageInfo, info );
+				console.log(info);
+				storage.update( data );
 			}
 
 			getApiEndpoint( endpoint ) {
-				const endpointData = this.state.apiProps.api[ endpoint ];
+				const endpointData = this.getApiProps().api[ endpoint ];
 				if ( ! endpointData ) {
 					this.fetchApiData( endpoint );
+					return null;
 				}
-				return this.state.apiProps.api[ endpoint ];
+				return endpointData;
 			}
 
 			fetchApiData( endpoint ) {
@@ -92,9 +97,9 @@ export function apiDataProvider() {
 				}
 				fetchRequiredApiEndpoint( endpoint )
 					.then( result => {
-						const api = Object.assign( {}, this.state.apiProps.api, result );
-						const apiProps = Object.assign( {}, this.state.apiProps, { api } );
-						this.setState( { apiProps } );
+						const data = storage.get();
+						data.apiData.api = Object.assign( {}, data.apiData.api, result );
+						storage.update( data );
 					} );
 			}
 

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -1,0 +1,66 @@
+import assign from 'lodash/assign';
+import storage from '~/src/lib/storage';
+
+var initialStateSaved = false;
+
+class Route {
+
+	constructor() {
+		this.initHistory();
+	}
+
+	initHistory() {
+		window.onpopstate = ( { state } ) => {
+			this.updatePageInfo( state );
+		};
+	}
+
+	isInternalLink( url ) {
+		// TODO:
+		return true;
+	}
+
+	/**
+	 * @param {String} url A relative URL to the wordpress root.
+	 * @param {Object} [postInfo] An object that contains information of a single post.
+	 *
+	 * @example
+	 * route.moveTo( '/' ); // go home. Call goHome() instead.
+	 * route.moveTo( '/2016/12/post-title', { id: 1, type: 'post', slug: 'post-title' } );
+	 */
+	moveTo( url, postInfo ) {
+		const data = storage.get();
+
+		if ( !this.isInternalLink( url ) ) {
+			location.url = url;
+			return;
+		}
+
+		if ( ! initialStateSaved ) {
+			history.replaceState( this.getPageInfo(), document.title, location.href );
+		}
+
+		// move to new page
+		this.updatePageInfo( { type: postInfo.type, postId: postInfo.id, slug: postInfo.slug } );
+
+		history.pushState( this.getPageInfo(), document.title, url );
+	}
+
+	goHome() {
+		this.moveTo( '/', { id: '', type: 'home', slug: 'home' } );
+	}
+
+	getPageInfo() {
+		return Object.assign( {}, storage.get().pageInfo );
+	}
+
+	updatePageInfo( newPageInfo ) {
+		const data = storage.get();
+		data.pageInfo = Object.assign( {}, data.pageInfo, newPageInfo );
+		storage.update( data );
+	}
+}
+
+const route = new Route();
+
+export default route;

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -19,7 +19,7 @@ function getHomeURL() {
  * @return {Boolean}
  */
 function isInternalLink( url ) {
-	return ( ! /^https?:/i.test( url ) ||  url.indexOf( this.getHomeURL() ) === 0 );
+	return ( ! /^https?:/i.test( url ) ||  url.toLowerCase().indexOf( getHomeURL().toLowerCase() ) === 0 );
 }
 
 /**
@@ -30,7 +30,7 @@ function isInternalLink( url ) {
  */
 function getRelativeURL( url ) {
 	if ( isInternalLink( url ) && url[0] !== '/' ) {
-		url = url.substr( this.getHomeURL().length );
+		url = url.substr( getHomeURL().length );
 		return ( ( url[0] === '/' ) ? '' : '/' ) + url;
 	}
 

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -10,6 +10,8 @@ class Route {
 	}
 
 	initHistory() {
+		if ( typeof window === 'undefined' ) return;
+
 		window.onpopstate = ( { state } ) => {
 			this.updatePageInfo( state );
 		};

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -17,12 +17,33 @@ class Route {
 		};
 	}
 
+	getHomeURL() {
+		try {
+			return storage.get().apiData.api['/component-themes/v1/settings'].wpurl;
+		} catch(e) {
+			return location.protocol + '//' + location.host;
+		}
+	}
+
 	isInternalLink( url ) {
-		// TODO:
-		return true;
+		return ( url[0] === '/' ||  url.indexOf( this.getHomeURL() ) === 0 );
 	}
 
 	/**
+	 * get
+	 */
+	getRelativeURL( url ) {
+		if ( this.isInternalLink( url ) && url[0] !== '/' ) {
+			url = url.substr( this.getHomeURL().length );
+			return ( ( url[0] === '/' ) ? '' : '/' ) + url;
+		}
+
+		return url;
+	}
+
+	/**
+	 * Move to the URL 
+	 *
 	 * @param {String} url A relative URL to the wordpress root.
 	 * @param {Object} [postInfo] An object that contains information of a single post.
 	 *
@@ -37,6 +58,8 @@ class Route {
 			location.url = url;
 			return;
 		}
+
+		url = this.getRelativeURL( url );
 
 		if ( ! initialStateSaved ) {
 			history.replaceState( this.getPageInfo(), document.title, location.href );

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -1,7 +1,41 @@
 import assign from 'lodash/assign';
 import storage from '~/src/lib/storage';
 
-var initialStateSaved = false;
+let initialStateSaved = false;
+
+function getHomeURL() {
+	try {
+		return storage.get().apiData.api['/component-themes/v1/settings'].wpurl;
+	} catch(e) {
+		return location.protocol + '//' + location.host;
+	}
+}
+
+
+/**
+ * Check whether a url is internal. Returns true when it points internal resources.
+ *
+ * @param {String} url URL string
+ * @return {Boolean}
+ */
+function isInternalLink( url ) {
+	return ( ! /^https?:/i.test( url ) ||  url.indexOf( this.getHomeURL() ) === 0 );
+}
+
+/**
+ * Get home-relative path of a url
+ *
+ * @param {String} url URL string
+ * @return {String}
+ */
+function getRelativeURL( url ) {
+	if ( isInternalLink( url ) && url[0] !== '/' ) {
+		url = url.substr( this.getHomeURL().length );
+		return ( ( url[0] === '/' ) ? '' : '/' ) + url;
+	}
+
+	return url;
+}
 
 class Route {
 
@@ -10,41 +44,19 @@ class Route {
 	}
 
 	initHistory() {
-		if ( typeof window === 'undefined' ) return;
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
 
 		window.onpopstate = ( { state } ) => {
 			this.updatePageInfo( state );
 		};
 	}
 
-	getHomeURL() {
-		try {
-			return storage.get().apiData.api['/component-themes/v1/settings'].wpurl;
-		} catch(e) {
-			return location.protocol + '//' + location.host;
-		}
-	}
-
-	isInternalLink( url ) {
-		return ( url[0] === '/' ||  url.indexOf( this.getHomeURL() ) === 0 );
-	}
-
-	/**
-	 * get
-	 */
-	getRelativeURL( url ) {
-		if ( this.isInternalLink( url ) && url[0] !== '/' ) {
-			url = url.substr( this.getHomeURL().length );
-			return ( ( url[0] === '/' ) ? '' : '/' ) + url;
-		}
-
-		return url;
-	}
-
 	/**
 	 * Move to the URL 
 	 *
-	 * @param {String} url A relative URL to the wordpress root.
+	 * @param {String} url A URL to move to.
 	 * @param {Object} [postInfo] An object that contains information of a single post.
 	 *
 	 * @example
@@ -54,18 +66,19 @@ class Route {
 	moveTo( url, postInfo ) {
 		const data = storage.get();
 
-		if ( !this.isInternalLink( url ) ) {
+		if ( ! isInternalLink( url ) ) {
 			location.url = url;
 			return;
 		}
 
-		url = this.getRelativeURL( url );
+		url = getRelativeURL( url );
 
 		if ( ! initialStateSaved ) {
+			initialStateSaved = true;
 			history.replaceState( this.getPageInfo(), document.title, location.href );
 		}
 
-		// move to new page
+		// move to the new page
 		this.updatePageInfo( { type: postInfo.type, postId: postInfo.id, slug: postInfo.slug } );
 
 		history.pushState( this.getPageInfo(), document.title, url );

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,0 +1,18 @@
+import Emitter from 'tiny-emitter';
+import assign from 'lodash/assign';
+
+var globalStorage = {};
+var listeners = {};
+
+class Storage extends Emitter {
+	get() {
+		return globalStorage;
+	}
+	update( newState ) {
+		globalStorage = assign( {}, globalStorage, newState );
+		this.emit( 'update' );
+	}
+}
+
+var storage = new Storage();
+export default storage;

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,5 +1,4 @@
 import Emitter from 'tiny-emitter';
-import assign from 'lodash/assign';
 
 let globalStorage = {};
 
@@ -8,7 +7,7 @@ class Storage extends Emitter {
 		return globalStorage;
 	}
 	update( newState ) {
-		globalStorage = assign( {}, globalStorage, newState );
+		globalStorage = Object.assign( {}, globalStorage, newState );
 		this.emit( 'update' );
 	}
 }

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,8 +1,7 @@
 import Emitter from 'tiny-emitter';
 import assign from 'lodash/assign';
 
-var globalStorage = {};
-var listeners = {};
+let globalStorage = {};
 
 class Storage extends Emitter {
 	get() {
@@ -14,5 +13,6 @@ class Storage extends Emitter {
 	}
 }
 
-var storage = new Storage();
+const storage = new Storage();
+
 export default storage;

--- a/src/themes/components/Link/index.js
+++ b/src/themes/components/Link/index.js
@@ -20,5 +20,24 @@ function Link( props ) {
 
 registerComponent( 'Link', Link, {
 	title: 'Link',
-	description: 'An anchor element that routes an application on client-side.',
+	description: 'An anchor element that supports client-side routing.',
+	hasChildren: true,
+	editableProps: {
+		url: {
+			type: 'string',
+			label: 'URL to move to'
+		},
+		postId: {
+			type: 'number',
+			label: 'Post ID'
+		},
+		postType: {
+			type: 'string',
+			label: 'Post type'
+		},
+		slug: {
+			type: 'string',
+			label: 'Post slug'
+		}
+	}
 } );

--- a/src/themes/components/Link/index.js
+++ b/src/themes/components/Link/index.js
@@ -1,0 +1,24 @@
+const ComponentThemes = window.ComponentThemes;
+const { React, registerComponent, route } = ComponentThemes;
+
+// Link React component
+function Link( props ) {
+	const postInfo = {
+		id: props.postId,
+		type: props.postType,
+		slug: props.slug
+	};
+
+	return (
+		<a
+			href={ props.url }
+			className={ props.className }
+			onClick={ (e) => { route.moveTo( props.url, postInfo ); e.preventDefault(); } }
+		>{props.children}</a>
+	);
+}
+
+registerComponent( 'Link', Link, {
+	title: 'Link',
+	description: 'An anchor element that routes an application on client-side.',
+} );

--- a/src/themes/components/Link/index.js
+++ b/src/themes/components/Link/index.js
@@ -9,11 +9,16 @@ function Link( props ) {
 		slug: props.slug
 	};
 
+	const clickHandler = ( event ) => {
+		route.moveTo( props.url, postInfo );
+		event.preventDefault();
+	};
+
 	return (
 		<a
 			href={ props.url }
 			className={ props.className }
-			onClick={ (e) => { route.moveTo( props.url, postInfo ); e.preventDefault(); } }
+			onClick={ clickHandler }
 		>{props.children}</a>
 	);
 }

--- a/src/themes/components/Link/index.php
+++ b/src/themes/components/Link/index.php
@@ -1,0 +1,13 @@
+<?php
+
+function Component_Themes_Link ( $props, $children ) {
+	$url = ct_get_value( $props, 'url' );
+	$class_name = ct_get_value( $props, 'className', '' );
+	return React::createElement(
+		'a',
+		array( 'className' => $class_name, 'href' => $url ),
+		$children
+	);
+};
+
+Component_Themes::register_component( 'Link', 'Component_Themes_Link' );

--- a/src/themes/components/PostBody/index.js
+++ b/src/themes/components/PostBody/index.js
@@ -1,11 +1,12 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent } = ComponentThemes;
+const { React, registerComponent, omit } = ComponentThemes;
 
-const PostBody = ( { content, date, link, author, title, children, className } ) => {
-	const newChildren = React.Children.map( children, child => React.cloneElement( child, { title, content, link, date, author } ) );
+const PostBody = ( props ) => {
+	const childProps = omit( props, [ 'className', 'children' ] );
+	const newChildren = React.Children.map( props.children, child => React.cloneElement( child, childProps ) );
 	return (
-		<div className={ className }>
+		<div className={ props.className }>
 			{ newChildren }
 		</div>
 	);

--- a/src/themes/components/PostDate/index.js
+++ b/src/themes/components/PostDate/index.js
@@ -17,7 +17,7 @@ const PostDate = ( { date, date_format, className } ) => {
 };
 
 const mapApiToProps = ( getApiEndpoint ) => {
-	const settings = getApiEndpoint( '/wp/v2/settings' ) || {};
+	const settings = getApiEndpoint( '/component-themes/v1/settings' ) || {};
 	return { date_format: settings.date_format };
 };
 

--- a/src/themes/components/PostDate/index.php
+++ b/src/themes/components/PostDate/index.php
@@ -15,7 +15,7 @@ function Component_Themes_PostDate( $props ) {
 }
 
 function Component_Themes_PostDate_Api_Mapper( $get_api_endpoint ) {
-	$settings = call_user_func( $get_api_endpoint, '/wp/v2/settings' );
+	$settings = call_user_func( $get_api_endpoint, '/component-themes/v1/settings' );
 
 	return array(
 		'date_format' => $settings['date_format'],

--- a/src/themes/components/PostList/index.js
+++ b/src/themes/components/PostList/index.js
@@ -3,8 +3,11 @@ const ComponentThemes = window.ComponentThemes;
 const { React, registerComponent, apiDataWrapper } = ComponentThemes;
 
 const PostList = ( { posts, children, className } ) => {
-	const newChildren = ( posts || [] ).map( ( { title, link, content, author, date } ) => {
-		return React.Children.map( children, child => React.cloneElement( child, { title, link, content, author, date } ) );
+	const newChildren = ( posts || [] ).map( ( postInfo ) => {
+		return React.Children.map(
+			children,
+			child => React.cloneElement( child, postInfo )
+		);
 	} );
 	return (
 		<div className={ className }>
@@ -19,6 +22,9 @@ const mapApiToProps = ( getApiEndpoint ) => {
 	const posts = postsData.map( post => {
 		const author = getApiEndpoint( '/wp/v2/users/' + post.author ) || {};
 		return {
+			postId: post.id,
+			postType: post.type,
+			slug: post.slug,
 			title: post.title.rendered,
 			content: post.content.rendered,
 			author: author.name,

--- a/src/themes/components/PostTitle/index.js
+++ b/src/themes/components/PostTitle/index.js
@@ -1,11 +1,17 @@
 /* globals window */
 const ComponentThemes = window.ComponentThemes;
-const { React, registerComponent } = ComponentThemes;
+const { React, registerComponent, getComponentByType } = ComponentThemes;
 
-const PostTitle = ( { link, title, className } ) => {
+const PostTitle = ( { link, title, className, slug, postId, postType } ) => {
+	const Link = getComponentByType('Link');
 	return (
 		<h1 className={ className }>
-			<a className="PostTitle_link" href={ link }>{ title || 'No title' }</a>
+			<Link
+				url={ link }
+				slug={ slug }
+				postId={ postId }
+				postType={ postType }
+				className="PostTitle_link">{ title || 'No title' }</Link>
 		</h1>
 	);
 };

--- a/src/themes/components/PostTitle/index.php
+++ b/src/themes/components/PostTitle/index.php
@@ -5,7 +5,11 @@ function Component_Themes_Post_Title ( $props ) {
 	$class_name = ct_get_value( $props, 'className', '' );
 	return React::createElement(
 		'h1', array( 'className' => $class_name ), array(
-			React::createElement( 'a', array( 'className' => 'PostTitle_link', 'href' => $link ), array( $link_text ) )
+			React::createElement(
+				'Link',
+				array( 'className' => 'PostTitle_link', 'url' => $link ),
+				array( $link_text )
+			)
 		)
 	);
 };

--- a/src/themes/components/core-components.js
+++ b/src/themes/components/core-components.js
@@ -16,3 +16,4 @@ import '~/src/themes/components/ColumnComponent';
 import '~/src/themes/components/PageLayout';
 import '~/src/themes/components/RowComponent';
 import '~/src/themes/components/SinglePost';
+import '~/src/themes/components/Link';


### PR DESCRIPTION
This PR will add client-side routing support to Component Themes. Here is a short description of the changes.
* An additional REST API endpoint provides general settings as public API.
* Route is a singleton class which manipulates history and navigation.
* Link is a component that supports client-side routing.
* PostTitle contains Link component to support client-side routing.
